### PR TITLE
Rainbow gem for color

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,14 @@
 PATH
   remote: .
   specs:
-    wirb (0.3.1)
+    wirb (0.3.2)
+      rainbow
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
+    rainbow (1.1.1)
     rake (0.8.7)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)

--- a/README.rdoc
+++ b/README.rdoc
@@ -29,7 +29,11 @@ The color schema can be changed with:
 
   Wirb.schema = { :comma => :purple, ... }
 
-Wirb color schemas are (almost) compatible with those from the original Wirble, but there are lots of extensions. Take a look at wirb/schema.rb or <tt>Wirb.schema</tt> for a list of available token descriptions. See wirb/colors.rb or <tt>Wirb::COLORS</tt> for the available colors.
+Wirb color schemas are (almost) compatible with those from the original Wirble, but there are lots of extensions. Take a look at wirb/schema.rb or <tt>Wirb.schema</tt> for a list of available token descriptions. See wirb/colors.rb or <tt>Wirb::Colors</tt> for the available colors and how to create your own.  Wirb uses rainbow[https://github.com/sickill/rainbow] for color and supports 256-color terminals.
+
+For support on Windows, you should install the following gems:
+
+  gem install windows-pr win32console
 
 Color schemas wanted! You've got a good looking alternative color schema? Please post it on the wiki[https://github.com/janlelis/wirb/wiki/schemas], it may be bundled with a next version ;)
 

--- a/lib/wirb/colors.rb
+++ b/lib/wirb/colors.rb
@@ -1,47 +1,106 @@
 module Wirb
-  COLORS = {
-    :nothing      => '0;0',
+  module Colors
+    # These are colors to provide compatibility with Wirble.
+    # You can define your own by doing by adding a method to Wirb::Colors
+    #
+    # A simple example:
+    #   class << Wirb::Colors
+    #     def mycolor string
+    #       string.foreground(:red).background(:blue).bright
+    #     end
+    #   end
+    #
+    # Then configure wirb to use it.
+    #   Wirb.schema[:string] = :mycolor
+    #
+    # See Wirb.schema.keys for the different colors you can change.
 
-    # light
-    :black        => '0;30',
-    :red          => '0;31',
-    :green        => '0;32',
-    :brown        => '0;33',
-    :blue         => '0;34',
-    :purple       => '0;35',
-    :cyan         => '0;36',
-    :light_gray   => '0;37',
-    
-    # bold
-    :dark_gray    => '1;30',
-    :light_red    => '1;31',
-    :light_green  => '1;32',
-    :yellow       => '1;33',
-    :light_blue   => '1;34',
-    :light_purple => '1;35',
-    :light_cyan   => '1;36',
-    :white        => '1;37',
+    class << self
+      def nothing s
+        s.reset
+      end
+      def brown s
+        s.foreground :yellow
+      end
+      def purple s
+        s.foreground :magenta
+      end
+      def light_gray s
+        s.foreground :white
+      end
+      def light_gray s
+        s.foreground :white
+      end
+      def dark_gray s
+        s.bright.foreground :black
+      end
+      def light_red s
+        s.bright.foreground :red
+      end
+      def light_green s
+        s.bright.foreground :green
+      end
+      def light_blue s
+        s.bright.foreground :blue
+      end
+      def light_purple s
+        s.bright.foreground :magenta
+      end
+      def light_cyan s
+        s.bright.foreground :cyan
+      end
 
-    # underline
-    :black_underline   => '4;30',
-    :red_underline     => '4;31',
-    :green_underline   => '4;32',
-    :brown_underline   => '4;33',
-    :blue_underline    => '4;34',
-    :purple_underline  => '4;35',
-    :cyan_underline    => '4;36',
-    :white_underline   => '4;37',
+      def black_underline s
+        s.underline.foreground :black
+      end
+      def red_underline s
+        s.underline.foreground :red
+      end
+      def green_underline s
+        s.underline.foreground :green
+      end
+      def brown_underline s
+        s.underline.foreground :yellow
+      end
+      def blue_underline s
+        s.underline.foreground :blue
+      end
+      def purple_underline s
+        s.underline.foreground :magenta
+      end
+      def cyan_underline s
+        s.underline.foreground :cyan
+      end
+      def white_underline s
+        s.underline.foreground :white
+      end
+      def black_background s
+        s.background :black
+      end
+      def red_background s
+        s.background :red
+      end
+      def green_background s
+        s.background :green
+      end
+      def brown_background s
+        s.background :yellow
+      end
+      def blue_background s
+        s.background :blue
+      end
+      def purple_background s
+        s.background :magenta
+      end
+      def cyan_background s
+        s.background :cyan
+      end
+      def white_background s
+        s.background :white
+      end
 
-    # background
-    :black_background   => '7;30',
-    :red_background     => '7;31',
-    :green_background   => '7;32',
-    :brown_background   => '7;33',
-    :blue_background    => '7;34',
-    :purple_background  => '7;35',
-    :cyan_background    => '7;36',
-    :white_background   => '7;37',
-  }
+    end
+  end
 end
 
 # J-_-L

--- a/wirb.gemspec
+++ b/wirb.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob(%w[{lib,test,spec}/**/*.rb bin/* [A-Z]*.{txt,rdoc} ext/**/*.{rb,c}]) + %w{Rakefile wirb.gemspec .gemtest}
   s.extra_rdoc_files = ["README.rdoc", "COPYING.txt"]
   s.license = 'MIT'
+  s.add_dependency 'rainbow'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This enables color support on more terminals and platforms by
using the rainbow gem for color.

Note that this should be fully backwards compatible with wirble even though this makes adding complicated colors (256 colors, hex-value colors) more complicated.

If you have any problems, comments, suggestions, just tell me.  My contact info is at http://docwhat.org/

Ciao!
