### PR TITLE
Side-step Gem.datadir deprecation warning

### DIFF
--- a/lib/wirb/schema_builder.rb
+++ b/lib/wirb/schema_builder.rb
@@ -14,7 +14,8 @@ module Wirb
 
      def self.resolve_schema_yaml(yaml_path)
        if yaml_path.is_a? Symbol # bundled themes
-         [yaml_path.to_s, YAML.load_file(File.join(Gem.datadir('wirb'), "#{yaml_path}.yml"))]
+         datadir = Gem.loaded_specs['wirb'].datadir
+         [yaml_path.to_s, YAML.load_file(File.join(datadir, "#{yaml_path}.yml"))]
        else
          [File.basename(yaml_path).gsub(/\.yml$/, ''), YAML.load_file(yaml_path)]
        end


### PR DESCRIPTION
`Gem.datadir` is deprecated, resulting in an ugly warning showing up on every `irb` session:

```
$ irb
Welcome to IRB. You are using ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]. Have fun ;)
>> _ #=> nil
NOTE: Gem.datadir is deprecated; use spec.datadir instead. It will be removed on or after 2016-10-01.
Gem.datadir called from /home/chastell/.gem/ruby/2.4.2/gems/wirb-2.1.1/lib/wirb/schema_builder.rb:17.
>> 
```

This fixes the deprecation by calling `Gem::BasicSpecification#datadir` instead.